### PR TITLE
Update to Mau 1.4

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Update the reader to Mau 1.4.0 and drop the deprecated configuration entry `no_document`

--- a/pelican/plugins/mau_reader/mau_reader.py
+++ b/pelican/plugins/mau_reader/mau_reader.py
@@ -28,7 +28,6 @@ class MauReader(BaseReader):
 
     def read(self, source_path):
         config = self.settings.get("MAU", {})
-        config["no_document"] = True
 
         output_format = config.get("output_format", "html")
         custom_templates = config.get("custom_templates", {})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 python = ">=3.6.2,<4.0"
 pelican = ">=4.5"
 markdown = {version = ">=3.2", optional = true}
-mau = "^1.3.0"
+mau = ">=1.4.0"
 
 [tool.poetry.dev-dependencies]
 black = {version = "^21.4b2", allow-prereleases = true}


### PR DESCRIPTION
This updates the code to drop the configuration entry `no_document` that Mau deprecated in version 1.4.0. The deafult value of the flag `full_document` is already what mau-reader wants to use so no further changes are needed.
The requirements have been updated to strictly use Mau >= 1.40